### PR TITLE
update getting started

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ MtBird 项目库的提交规范采用 [Angular 提交规范](https://zj-git-guid
 ```shell
 git clone https://github.com/staringos/mtbird
 yarn
-lerna bootstrap
+yarn bootstrap
 yarn start
 ```
 
@@ -31,16 +31,11 @@ yarn start
 
 ## 调试本地模块
 
-```shell
-cd packages/mtbird-example
-yarn run link
-```
-
-这时候，example 中所有 mtbird 相关依赖都会被 link 到本地，您可以在本地开启代码监听，进行代码修改，example 中的引用会自动更新。比如修改 editor 模块:
+这时候，example 中所有 mtbird 相关依赖已经被 link 到本地，您可以在本地开启代码监听，进行代码修改，example 中的引用会自动更新。比如修改 editor 模块:
 
 ```shell
 cd packages/mtbrid-editor
-yarn run start
+yarn start
 ```
 
 ## Packages

--- a/README-CN.md
+++ b/README-CN.md
@@ -35,7 +35,7 @@
 ```shell
 git clone https://github.com/staringos/mtbird
 yarn
-yarn run bootstrap
+yarn bootstrap
 yarn start
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Require NodeJS version: >=14.18.0
 ```shell
 git clone https://github.com/staringos/mtbird
 yarn
-yarn run bootstrap
+yarn bootstrap
 yarn start
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-version": "lerna version prerelease --force-publish --conventional-commits",
     "build": "lerna run build",
     "publish": "lerna publish from-package --yes --registry https://registry.npmjs.org/",
-    "link": "yanr link @mtbird/component-basic & yarn link @mtbird/renderer-web & yarn link @mtbird/shared & yarn link @mtbird/ui",
+    "link": "yarn link @mtbird/component-basic & yarn link @mtbird/helper-component& yarn link @mtbird/renderer-web & yarn link @mtbird/shared & yarn link @mtbird/ui",
     "lint": "yarn prettier --write ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,11 @@
   ],
   "scripts": {
     "start": "lerna run start --scope=@mtbird/example --stream",
-    "bootstrap": "lerna exec yarn",
-    "link-dev": "lerna exec yarn link",
+    "bootstrap": "lerna exec yarn && yarn build && lerna exec yarn link && yarn link-pkg",
+    "link-pkg": "yarn link @mtbird/component-basic & yarn link @mtbird/helper-component & yarn link @mtbird/renderer-web & yarn link @mtbird/shared & yarn link @mtbird/ui && lerna run link-pkg --scope=@mtbird/example --stream",
     "update-version": "lerna version prerelease --force-publish --conventional-commits",
     "build": "lerna run build",
     "publish": "lerna publish from-package --yes --registry https://registry.npmjs.org/",
-    "link": "yarn link @mtbird/component-basic & yarn link @mtbird/helper-component& yarn link @mtbird/renderer-web & yarn link @mtbird/shared & yarn link @mtbird/ui",
     "lint": "yarn prettier --write ."
   },
   "devDependencies": {

--- a/packages/mtbird-component-basic/package.json
+++ b/packages/mtbird-component-basic/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "start": "NODE_ENV=development mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "preDev": "lerna link & yarn run link",
-    "link": "npm link ../../../mtbird-saas/node_modules/react"
+    "preDev": "lerna link & yarn link-pkg",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react"
   },
   "bugs": {
     "url": "https://github.com/staringos/mtbird/issues"

--- a/packages/mtbird-editor/package.json
+++ b/packages/mtbird-editor/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "start": "rimraf dist & NODE_ENV=development mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "preDev": "npm-install-peers & lerna link & yarn run link",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
+    "preDev": "npm-install-peers & lerna link & yarn link-pkg",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "dependencies": {

--- a/packages/mtbird-editor/src/components/DebugButton/index.tsx
+++ b/packages/mtbird-editor/src/components/DebugButton/index.tsx
@@ -18,6 +18,7 @@ const DebugPanel = () => {
       content: "确认开始调试吗？（页面需刷新，请保存修改！）",
       okText: "确定",
       cancelText: "取消",
+      zIndex: 1040,
       onOk() {
         GlobalStorage.debugExtension = debug;
         location.reload();
@@ -31,6 +32,7 @@ const DebugPanel = () => {
       content: "确认停止调试吗？（页面需刷新，请保存修改！）",
       okText: "确定",
       cancelText: "取消",
+      zIndex: 1040,
       onOk() {
         GlobalStorage.debugExtension = null;
         location.reload();

--- a/packages/mtbird-example/README.md
+++ b/packages/mtbird-example/README.md
@@ -4,28 +4,17 @@ MtBird example for editor and web renderer
 
 ## Getting Started
 
-run in local
+run in root dir
 
 ```shell
 yarn
-yarn run start
+yarn bootstrap
+yarn start
 ```
 
 ## Dev mtbird Lib
 
-cd mtbird root dir
-
-```shell
-lerna link
-```
-
-```
-cd packages/mtbird-example
-yarn run link
-yarn run start
-```
-
-link script will help you link all mtbird library
+All mtbird packages are now linked locally
 
 and you can going to library you want to modify, like @mtbird/editor
 

--- a/packages/mtbird-example/package.json
+++ b/packages/mtbird-example/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.3-beta.46",
   "private": true,
   "scripts": {
-    "link": "yarn link @mtbird/ui & yarn link @mtbird/core & yarn link @mtbird/shared & yarn link @mtbird/component-basic & yarn link @mtbird/renderer-web & yarn link @mtbird/editor & yarn link @mtbird/helper-component & yarn link @mtbird/helper-extension",
-    "start": "next dev",
+    "link-pkg": "yarn link @mtbird/ui & yarn link @mtbird/core & yarn link @mtbird/shared & yarn link @mtbird/component-basic & yarn link @mtbird/renderer-web & yarn link @mtbird/editor & yarn link @mtbird/helper-component & yarn link @mtbird/helper-extension",
+    "start": "yarn clean && next dev",
     "build": "next build",
     "start-product": "next start",
+    "clean": "rimraf .next",
     "lint": "next lint"
   },
   "dependencies": {

--- a/packages/mtbird-extension-image-library/package.json
+++ b/packages/mtbird-extension-image-library/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "NODE_ENV=production mtbird start",
     "build": "NODE_ENV=production mtbird build",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
-    "preDev": "lerna link & yarn run link",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
+    "preDev": "lerna link & yarn link-pkg",
     "publish-lib": "NODE_ENV=production mtbird publish --token=",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },

--- a/packages/mtbird-helper-component/package.json
+++ b/packages/mtbird-helper-component/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "start": "NODE_ENV=production mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
-    "preDev": "lerna link & yarn run link",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
+    "preDev": "lerna link & yarn link-pkg",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "peerDependencies": {

--- a/packages/mtbird-helper-extension/package.json
+++ b/packages/mtbird-helper-extension/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "start": "NODE_ENV=production mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
-    "preDev": "lerna link & yarn run link",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
+    "preDev": "lerna link & yarn link-pkg",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "devDependencies": {

--- a/packages/mtbird-renderer-web/package.json
+++ b/packages/mtbird-renderer-web/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "start": "NODE_ENV=development mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
-    "preDev": "lerna link && yarn run link",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
+    "preDev": "lerna link && yarn link-pkg",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "peerDependencies": {

--- a/packages/mtbird-shared/package.json
+++ b/packages/mtbird-shared/package.json
@@ -23,7 +23,7 @@
     "start": "NODE_ENV=production mtbird watch",
     "build": "NODE_ENV=production mtbird build",
     "preDev": "echo \"1\"",
-    "link": "npm link ../../../mtbird-saas/node_modules/react",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react",
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "peerDependencies": {

--- a/packages/mtbird-storybook/README.md
+++ b/packages/mtbird-storybook/README.md
@@ -3,5 +3,5 @@
 ```shell
 yarn global add sb
 yarn
-yarn run start
+yarn start
 ```

--- a/packages/mtbird-storybook/package.json
+++ b/packages/mtbird-storybook/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "test-storybook": "test-storybook",
     "start": "start-storybook -p 6006 -s public",
-    "link": "yarn link @mtbird/ui & yarn link @mtbird/core & yarn link @mtbird/shared & yarn link @mtbird/component-basic & yarn link @mtbird/renderer-web & yarn link @mtbird/editor & yarn link @mtbird/helper-component & yarn link @mtbird/helper-extension",
+    "link-pkg": "yarn link @mtbird/ui & yarn link @mtbird/core & yarn link @mtbird/shared & yarn link @mtbird/component-basic & yarn link @mtbird/renderer-web & yarn link @mtbird/editor & yarn link @mtbird/helper-component & yarn link @mtbird/helper-extension",
     "build": "build-storybook -s public -c .storybook",
     "generate": "yarn build && npx sb extract && mv ./storybook-static/stories.json ./storybook-static/sitemap.json"
   },

--- a/packages/mtbird-ui/package.json
+++ b/packages/mtbird-ui/package.json
@@ -26,8 +26,8 @@
   "scripts": {
     "start": "NODE_ENV=development mtbird watch",
     "build": "NODE_ENV=production mtbird build",
-    "preDev": "lerna link & yarn run link",
-    "link": "npm link ../../../mtbird-saas/node_modules/react"
+    "preDev": "lerna link & yarn link-pkg",
+    "link-pkg": "npm link ../../../mtbird-saas/node_modules/react"
   },
   "bugs": {
     "url": "https://github.com/staringos/mtbird/issues"


### PR DESCRIPTION
## Why
初次参与贡献时搭建开发流程较为繁琐，需要精简搭建环境的流程

## How
- [x] 在根目录执行命令（yarn && yarn bootstrap && yarn start），就可以跑起来一个应用
- [x] 如果需要修改某个的代码，只需要在对应的包执行 yarn run start，就可以在 1 的基础上监听这个包的代码更新

## Other
- [x] yarn run link 和 yarn link 会造成歧义，因此改为 yarn link-pkg
- [x] 解决歧义问题后，则无需再使用 yarn run \<script-name> 的方式，直接使用 yarn \<script-name> 即可

## Test
```shell
# 确保本地没有 link 过 mtbird 相关的包
> rm -rf ~/.config/yarn/link/@mtbird

# 拉取代码
> git clone git@github.com:gd4Ark/mtbird.git 
> cd mtbird
> git checkout feature/update-getting-started
# bootstrap 时会全量 build 一次，因此比较久
> yarn && yarn bootstrap && yarn start

# 修改某个包的代码
> cd packages/mtbird-editor
> yarn start
```
测试更新代码是否正常监听